### PR TITLE
Fix total entries when query has combinations

### DIFF
--- a/test/scrivener/paginator/ecto/query_test.exs
+++ b/test/scrivener/paginator/ecto/query_test.exs
@@ -320,6 +320,18 @@ defmodule Scrivener.Paginator.Ecto.QueryTest do
       assert page.total_entries == 2
     end
 
+    test "can be used with combinations" do
+      create_posts()
+
+      page =
+        Post
+        |> Post.published()
+        |> union(^Post.unpublished(Post))
+        |> Scrivener.Ecto.Repo.paginate()
+
+      assert page.total_entries == 7
+    end
+
     test "can be provided a Scrivener.Config directly" do
       posts = create_posts()
 


### PR DESCRIPTION
Currently, `Repo.paginate` may throw an exception if the query has combinations.

Test case:
```elixir
Post
|> Post.published()
|> union(^Post.unpublished(Post))
|> Scrivener.Ecto.Repo.paginate()
```
Exception message:
```shell
** (Postgrex.Error) ERROR 42601 (syntax_error) each UNION query must have the same number of columns
    query: SELECT count('*') FROM "posts" AS p0 WHERE (p0."published" = TRUE) UNION (SELECT p0."id", p0."title", p0."body", p0."published", p0."inserted_at", p0."updated_at" FROM "posts" AS p0 WHERE (p0."published" = FALSE))
```
Inspiration from [ecto](https://github.com/elixir-ecto/ecto/pull/3703), I direct use `Ecto.Query.aggregate` to count total entries except query has group_bys.