### PR TITLE
Fix issue that caused certain uses of `select` to break

### DIFF
--- a/lib/scrivener/paginater/ecto/query.ex
+++ b/lib/scrivener/paginater/ecto/query.ex
@@ -17,7 +17,7 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
       options
       |> Keyword.put_new(:caller, caller)
       |> Keyword.get_lazy(:total_entries, fn ->
-        aggregate(%{query | select: nil}, repo, options)
+        aggregate(query, repo, options)
       end)
 
     total_pages = total_pages(total_entries, page_size)
@@ -73,7 +73,9 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
   end
 
   defp aggregate(query, repo, options) do
-    repo.aggregate(query, :count, options)
+    query
+    |> exclude(:select)
+    |> repo.aggregate(:count, options)
   end
 
   defp total_pages(0, _), do: 1

--- a/lib/scrivener/paginater/ecto/query.ex
+++ b/lib/scrivener/paginater/ecto/query.ex
@@ -17,7 +17,7 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
       options
       |> Keyword.put_new(:caller, caller)
       |> Keyword.get_lazy(:total_entries, fn ->
-        aggregate(query, repo, options)
+        aggregate(%{query | select: nil}, repo, options)
       end)
 
     total_pages = total_pages(total_entries, page_size)

--- a/test/scrivener/paginator/ecto/query_test.exs
+++ b/test/scrivener/paginator/ecto/query_test.exs
@@ -441,6 +441,24 @@ defmodule Scrivener.Paginator.Ecto.QueryTest do
       assert page.total_pages == 1
     end
 
+    test "pagination plays nice with distinct when selecting a map with a struct value" do
+      create_posts()
+
+      query =
+        from(post in Post,
+          distinct: post.id,
+          select: %{post: post}
+        )
+
+      page = Scrivener.Ecto.Repo.paginate(query)
+
+      assert length(page.entries) == 5
+      assert page.page_size == 5
+      assert page.page_number == 1
+      assert page.total_entries == 7
+      assert page.total_pages == 2
+    end
+
     test "can specify prefix" do
       create_users(6, "tenant_1")
       create_users(2, "tenant_2")


### PR DESCRIPTION
Depending on the shape of your query, Ecto may run it as a subquery when using aggregate functions. Ecto has rules for select clauses in subqueries that do not apply to queries run normally. Because Scrivener does an aggregate by count, it chokes on certain queries that Ecto wants to convert to subqueries but can't. This change addresses the issue by always ignoring select clauses when aggregating.

Ecto issue for reference: https://github.com/elixir-ecto/ecto/issues/