### PR TITLE
support `max_total_entries` option

### DIFF
--- a/test/scrivener/paginator/ecto/query_test.exs
+++ b/test/scrivener/paginator/ecto/query_test.exs
@@ -233,6 +233,32 @@ defmodule Scrivener.Paginator.Ecto.QueryTest do
       assert page.total_entries == 130
     end
 
+    test "will respect max_total_entries passed to paginate" do
+      create_posts()
+
+      page =
+        Post
+        |> Post.published()
+        |> Scrivener.Ecto.Repo.paginate(options: [max_total_entries: 4])
+
+      assert length(page.entries) == 5
+      assert page.total_entries == 4
+    end
+
+    test "will respect max_total_entries passed to paginate with a group by clause on field on joined table" do
+      create_posts()
+
+      page =
+        Post
+        |> join(:inner, [p], c in assoc(p, :comments))
+        |> group_by([p, c], c.body)
+        |> select([p, c], {c.body, count("*")})
+        |> Scrivener.Ecto.Repo.paginate(options: [max_total_entries: 1])
+
+      assert length(page.entries) == 2
+      assert page.total_entries == 1
+    end
+
     test "will use total_pages if page_numer is too large" do
       posts = create_posts()
 


### PR DESCRIPTION
I'm finding that for paginating tables with hundreds of thousands of rows, it can take a long time to simply count the records in the table - even if all filters are indexed properly.

I had the thought that we could optionally apply a limit when counting the total rows. Of course this could result in incorrect `total_entries` and `total_pages`, but my thought is that this can be handled in a UI with something like "viewing page 1 of 100+ pages" and "viewing 25 of 1000+ entries".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for capping the total number of entries counted during pagination using a maximum limit option.

- **Tests**
  - Introduced tests to verify that pagination correctly respects the maximum total entries limit, including scenarios with grouped and joined queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->